### PR TITLE
Fix: Email-register

### DIFF
--- a/src/auth/dto/auth-register-login.dto.ts
+++ b/src/auth/dto/auth-register-login.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, MinLength, Validate } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  Matches,
+  MinLength,
+  Validate,
+} from 'class-validator';
 import { IsNotExist } from 'src/utils/validators/is-not-exists.validator';
 import { Transform } from 'class-transformer';
 import { lowerCaseTransformer } from 'src/utils/transformers/lower-case.transformer';
@@ -14,7 +20,14 @@ export class AuthRegisterLoginDto {
   email: string;
 
   @ApiProperty()
-  @MinLength(6)
+  @MinLength(8, { message: 'Password must be at least 8 characters long' })
+  @Matches(
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/i,
+    {
+      message:
+        'Password must contain at least one lowercase letter[a-z], one uppercase letter[A-Z], one digit[0-9], and one special character (@$!%*?&)',
+    },
+  )
   password: string;
 
   @ApiProperty({ example: 'John' })

--- a/src/utils/errorsHandler/emailRegisterCustomErrorHandler.ts
+++ b/src/utils/errorsHandler/emailRegisterCustomErrorHandler.ts
@@ -1,0 +1,27 @@
+import { HttpStatus } from '@nestjs/common';
+
+export class EmailRegisterCustomErrorHandler {
+  static handle(error: Error): { status: number; message: string } {
+    if (error.message === 'Failed to send the confirmation email.') {
+      return {
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Failed to send the confirmation email. Please try again later.',
+      };
+    } else if (
+      error.message === 'Email service credentials are not properly configured.'
+    ) {
+      return {
+        status: HttpStatus.CONFLICT,
+        message:
+          'The email service is not properly configured. Please contact the administrator.',
+      };
+    } else {
+      return {
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+        message:
+          'An error occurred while processing your request. Please try again later.',
+      };
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
      *  User signup with email

#### WHAT CHANGES

    Password needs to have the following
      - At least one lowercase letter (a-z)
      - At least one uppercase letter (A-Z)
      - At least one number (0-9)
      - At least one special character (@$!%*?&)
      - Minimum length of 8 characters
      - On Successfully, User receive any email to confirm 

    Now the following are handles
        - On Reset Password, email is being sent and Password reset Successfully
        - User is able to see clear Return messages on failure or success
        - Error from sendGrid are being handled correctly with clear message

#### How should this be manually tested? 
  * Clone the branch
  * Go to its path in terminal run: yarn install for Dependencies
  * Do database related
  * Start the app and then
  * Use Swagger: http://localhost:3000/docs 
  * Go to Auth and then email/register
  * You gonna need to use a real email 
  * On success you get 204

